### PR TITLE
Publishing data

### DIFF
--- a/CDO.md
+++ b/CDO.md
@@ -1,3 +1,0 @@
-### CDO
-Well I never use CDO so I'm not sure if we want them to be able to do a) the same as with NCO or b) different things. If a) then they should be in the same file and be a "NCO or CDO" title.
-If b), what different things?

--- a/DMP_details.md
+++ b/DMP_details.md
@@ -2,3 +2,5 @@
  * What a DMP is
  * The DMP lifecycle: using it to keep track of your data and data workflows
  * Where to fill a DMP for your data
+
+[Link to training](???)

--- a/Data_formatting.md
+++ b/Data_formatting.md
@@ -1,7 +1,6 @@
 ### Files and directories formatting
- * [Shell](Shell.md)
- * [Python](Python_files.md)
- * [NCO](NCO.md)
- * [CDO](CDO.md)
- * CF conventions
- * ACDD conventions
+ * Pre-requisites: [Shell](Shell.md)
+ * File format conventions: CF and ACDD
+ * Split/concatenate your files, extract variables, work with the time axis
+
+[Details of the training](Data_formatting_details.md)

--- a/Data_formatting_details.md
+++ b/Data_formatting_details.md
@@ -1,0 +1,16 @@
+### Conventions
+[Link to resources](???)
+
+### Files and directories formatting
+ * Using Python:  
+    * Create, delete, move files and directories in Python
+    * Work with netcdf files in Python
+    * Work with datetime objects to customise the time coordinate in Python
+
+ * NCO and CDO:
+    * Concatenating files:
+        * Difference between record and ensemble concatenation
+    * Attributes editing
+    * Splitting along variables and dimensions
+
+[Link to the training](???)

--- a/NCO.md
+++ b/NCO.md
@@ -1,5 +1,0 @@
-### File formatting with NCO
- * Concatenating files
-   * Difference between record and ensemble concatenation
- * Attributes editing
- * Splitting along variables and dimensions

--- a/Open_Access_details.md
+++ b/Open_Access_details.md
@@ -7,3 +7,6 @@ There are two main reasons to publish your data. The first is to provide a new d
  * The journals policies about Open Access.
  * What data you should publish.
  * The data repositories available to you and their requirements.
+
+[Link to resources](???)
+[Link to training](???)

--- a/Publication_process.md
+++ b/Publication_process.md
@@ -1,3 +1,0 @@
-### Submit data for publication
- * How to submit your data
- * What happens after submission

--- a/Publication_process_details.md
+++ b/Publication_process_details.md
@@ -1,0 +1,10 @@
+### Requirements for data publication
+ * Data management plan
+ * Formatting files according to conventions
+The previous points are explained in details in subsequent trainings.
+
+### Submit data for publication
+ * How to submit your data
+ * What happens after submission
+
+[Link to resources](???)

--- a/Python_files.md
+++ b/Python_files.md
@@ -1,4 +1,0 @@
-### Using Python to manage files and directories
- * Create, delete, move files and directories in Python
- * Work with netcdf files in Python
- * Work with datetime objects to customise the time coordinate in Python

--- a/workflow.md
+++ b/workflow.md
@@ -70,9 +70,9 @@ For NCI Users
 
 <details><summary>Publishing data - Claire rev. Aidan</summary>
 
-  * [Open Access Requirements](Open_Access.md)
-  * [Publication process](Publication_process.md)
-  * [Complete a Data Management plan](DMP.md)
+  * [Open Access Requirements](Open_Access_details.md)
+  * [Publication process](Publication_process_details.md)
+  * [Complete a Data Management plan](DMP_details.md)
   * [Format your data](Data_formatting.md)
 </details>
 


### PR DESCRIPTION
I've modified quite a bit. For one, I've linked better the trainings on formatting the data. I've assumed we would run one training on how to do it with Python and one on how to do it with NCO/CDO.
I haven't checked yet but the Python training might be covered by Data Analysis. 

Normally we agreed on organising the info in 3 tiers:
- workflow
     - overview of training
           - detail of training (with links to resources/trainings)

I found for this part I was not able to differentiate overview and detail. The detail documents is the one we will use as a reminder of what we want to cover in each training. Maybe @paolap you'll be better placed than me to know if what's there is enough or you want more details.
The convention I've used for the filenames is: `<name>.md` and `<name>_details.md` so if you add some files, please keep this convention.

And I haven't yet looked for the trainings or resources we would point to, just placeholder right now.
